### PR TITLE
theory that extra reconcile causes timing issues in canaries

### DIFF
--- a/pkg/controller/sync/policy_spec_sync.go
+++ b/pkg/controller/sync/policy_spec_sync.go
@@ -147,9 +147,10 @@ func (r *ReconcilePolicy) Reconcile(request reconcile.Request) (reconcile.Result
 			r.managedRecorder.Event(instance, "Normal", "PolicySpecSync",
 				fmt.Sprintf("Policy %s was synchronized to cluster namespace %s", instance.GetName(),
 					instance.GetNamespace()))
+		} else {
+			reqLogger.Error(err, "Failed to get policy from managed...")
+			return reconcile.Result{}, err
 		}
-		reqLogger.Error(err, "Failed to get policy from managed...")
-		return reconcile.Result{}, err
 	}
 	// found, then compare and update
 	if !common.CompareSpecAndAnnotation(instance, managedPlc) {


### PR DESCRIPTION
Looking at the spec sync logs I am seeing evidence that we error out when we don't need to.  Example:

```
2021-03-12T18:16:39.341436184Z {"level":"info","ts":1615572999.3405137,"logger":"policy-spec-sync","msg":"Reconciling Policy...","Request.Namespace":"import-219938454","Request.Name":"policy-test.policy-gatekeeper-operator"}
2021-03-12T18:16:39.351795182Z {"level":"info","ts":1615572999.3511357,"logger":"policy-spec-sync","msg":"Policy not found on managed cluster, creating it...","Request.Namespace":"import-219938454","Request.Name":"policy-test.policy-gatekeeper-operator"}
2021-03-12T18:16:39.387784899Z {"level":"error","ts":1615572999.3861175,"logger":"policy-spec-sync","msg":"Failed to get policy from managed...","Request.Namespace":"import-219938454","Request.Name":"policy-test.policy-gatekeeper-operator","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/remote-source/deps/gomod/pkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:128\ngithub.com/open-cluster-management/governance-policy-spec-sync/pkg/controller/sync.(*ReconcilePolicy).Reconcile\n\t/remote-source/app/pkg/controller/sync/policy_spec_sync.go:149\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/remote-source/deps/gomod/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.2/pkg/internal/controller/controller.go:256\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/remote-source/deps/gomod/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.2/pkg/internal/controller/controller.go:232\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/remote-source/deps/gomod/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.2/pkg/internal/controller/controller.go:211\nk8s.io/apimachinery/pkg/util/wait.JitterUntil.func1\n\t/remote-source/deps/gomod/pkg/mod/k8s.io/apimachinery@v0.17.4/pkg/util/wait/wait.go:152\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/remote-source/deps/gomod/pkg/mod/k8s.io/apimachinery@v0.17.4/pkg/util/wait/wait.go:153\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/remote-source/deps/gomod/pkg/mod/k8s.io/apimachinery@v0.17.4/pkg/util/wait/wait.go:88"}

```

And we then do the reconcile that completes later:

```
2021-03-12T18:18:30.974121400Z {"level":"info","ts":1615573110.974047,"logger":"policy-spec-sync","msg":"Policy mismatch between hub and managed, updating it...","Request.Namespace":"import-219938454","Request.Name":"policy-test.policy-gatekeeper-operator"}
2021-03-12T18:18:30.999324947Z {"level":"info","ts":1615573110.999243,"logger":"policy-spec-sync","msg":"Reconciliation complete.","Request.Namespace":"import-219938454","Request.Name":"policy-test.policy-gatekeeper-operator"}
```

That's 2 minutes of delay.

Found as part of investigation into https://github.com/open-cluster-management/backlog/issues/10422
I think this is likely also the cause of the 2.1.5 canary issues, though need to double check.