### PR TITLE
[release-2.4] Use Leader-with-lease election 

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -23,7 +22,6 @@ import (
 	"github.com/open-cluster-management/governance-policy-spec-sync/pkg/controller"
 	"github.com/open-cluster-management/governance-policy-spec-sync/version"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
-	"github.com/operator-framework/operator-sdk/pkg/leader"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"github.com/spf13/pflag"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -100,16 +98,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	ctx := context.TODO()
-	// Become the leader before proceeding
-	err = leader.Become(ctx, "policy-spec-sync-lock")
-	if err != nil {
-		log.Error(err, "")
-		os.Exit(1)
-	}
-
 	// Set default manager options
 	options := manager.Options{
+		LeaderElection:         true,
+		LeaderElectionID:       "policy-spec-sync-lock",
+		LeaderElectionConfig:   managedCfg,
 		Namespace:              namespace,
 		MetricsBindAddress:     fmt.Sprintf("%s:%d", metricsHost, metricsPort),
 		HealthProbeBindAddress: tool.Options.ProbeAddr,


### PR DESCRIPTION
The default Leader-for-life blocks the entire operator from starting
until obtains the leadership. This will cause deadlock with healthiness
probes from manager. Switching to Leader-with-lease from manager
to better work with healthiness probes.
See https://tinyurl.com/3znyd86y

Tested on OCP 4.9 and k8s v1.11 using KinD to ensure OCP 3.11
compatibility

For https://github.com/open-cluster-management/backlog/issues/17651

Signed-off-by: Yu Cao <ycao@redhat.com>